### PR TITLE
Addition of an text view to display result the result in Vat and Gst …

### DIFF
--- a/app/src/main/res/layout/fragment_vat_gst.xml
+++ b/app/src/main/res/layout/fragment_vat_gst.xml
@@ -101,7 +101,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="visible"
             android:orientation="vertical">
 
             <LinearLayout
@@ -128,13 +127,27 @@
                     android:text="Remove VAT" />
             </LinearLayout>
 
-
-            <TextView
-                android:id="@+id/vatResult"
-                android:layout_width="187dp"
+            <LinearLayout
+                android:layout_width="wrap_content"
                 android:layout_height="61dp"
-                android:layout_marginLeft="100dp"
-                android:text="@string/result" />
+                android:layout_gravity="center"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="61dp"
+                    android:textSize="66px"
+                    android:text="@string/result"/>
+
+                <TextView
+                    android:id="@+id/vatResult"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:textSize="66px"
+                    android:text="0.0" />
+
+
+            </LinearLayout>
 
         </LinearLayout>
 
@@ -229,14 +242,28 @@
                     android:layout_marginLeft="60dp"
                     android:layout_marginTop="26dp"/>
             </LinearLayout>
-
-
-            <TextView
-                android:id="@+id/gstResult"
-                android:layout_width="187dp"
+            <LinearLayout
+                android:layout_width="wrap_content"
                 android:layout_height="61dp"
-                android:layout_marginLeft="100dp"
-                android:text="@string/result" />
+                android:layout_gravity="center"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="61dp"
+                    android:textSize="66px"
+                    android:text="@string/result"/>
+
+                <TextView
+                    android:id="@+id/gstResult"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:textSize="66px"
+                    android:text="0.0" />
+
+
+            </LinearLayout>
+
 
 
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="calculate_vat">Calculate VAT</string>
     <string name="enter_rate">Enter Rate</string>
     <string name="enter_amount">Enter Amount</string>
-    <string name="result">Result</string>
+    <string name="result">Result: </string>
     <string name="remove_vat">Remove Vat</string>
     <string name="add_vat">Add Vat</string>
     <string name="contact">Contact Us</string>


### PR DESCRIPTION
Instead of displaying the result in place of the existing result text view, I have added a new text view to display the result in the same row.
# Description 


Fixes #50 <br>
Contributor: Srijan De
## Type of change

- [x] Bug fix 
- [x] New feature 
- [x] This change requires a documentation update

# Snapshot of the UI 
Calculate VAT :
![vatres](https://user-images.githubusercontent.com/50512505/73131291-7abb7400-402e-11ea-8eea-eb213596b852.png)
Calculate GST :
![gstres](https://user-images.githubusercontent.com/50512505/73131289-6aa39480-402e-11ea-8c78-dedc670e1a7a.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
